### PR TITLE
Update20191212

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -301,15 +301,14 @@ function trelloReport(){
   }
  
   // Create a new sheet in this Google Spreadsheet
-  var now = Utilities.formatDate(new Date(), 'JST', 'yyyyMMddHHmmss');
+  var now = Utilities.formatDate(new Date(), timeZone, 'yyyyMMddHHmmss');
   var sheetName = 'TrelloReport' + now;
   
   var reportSS = SpreadsheetApp.getActiveSpreadsheet();
   var reportSheet = reportSS.insertSheet(sheetName, 0); // Insert new sheet at the left-most position (<- sheetIndex = 0)
-  var headerRange = reportSheet.getRange(1,1,1,header[0].length);
-  var headerData = headerRange.setValues(header);
-  var reportRange = reportSheet.getRange(2,1,data.length,header[0].length);
-  var reportData = reportRange.setValues(data);
+  var sheetTitle = reportSheet.getRange(1,1).setValue('Trello Board Name: ' + boardName);
+  var sheetHeader = reportSheet.getRange(3,1,1,header[0].length).setValues(header);
+  var reportData = reportSheet.getRange(4,1,data.length,header[0].length).setValues(data);
 }
 
 
@@ -327,3 +326,4 @@ function deleteArchivedCards() {
     Logger.log(deleted);
   }
 }
+

--- a/common.gs
+++ b/common.gs
@@ -9,13 +9,16 @@ function onOpen(e) {
   .addToUi();
 }
 
+// Global params
+var timeZone = Session.getScriptTimeZone();
+
 /**
  * Standarized Date Format for this project.
  * @param {string} dateString
  * @return {string} dateIso
  */
 function stDate(dateString) {
-  var dateIso = Utilities.formatDate(new Date(dateString), 'JST', "yyyy-MM-dd'T'HH:mm:ssXXX");
+  var dateIso = Utilities.formatDate(new Date(dateString), timeZone, "yyyy-MM-dd'T'HH:mm:ssXXX");
   return dateIso;
 }
 


### PR DESCRIPTION
- Added title row to include Trello board name in report
- Use of Session.getScriptTimeZone() instead of designating a fixed time zone (e.g., 'JST')